### PR TITLE
Abbreviated values in summary and added tooltip to view the actual value

### DIFF
--- a/src/summaryTable.js
+++ b/src/summaryTable.js
@@ -22,6 +22,14 @@ export const initSummaryTable = (containerId) => {
   const table = d3.select(id).append('table').attr('class', 'summary-table');
 };
 
+function abbreviateNumber(value) {
+  return d3.format(".3s")(value);
+}
+
+function formatNumberWithCommas(value) {
+  return d3.format(",r")(value);
+}
+
 /**
  * Create a summary table for a chart
  * @param  {string} containerId id of chart
@@ -72,8 +80,10 @@ export const createSummaryTable = (containerId, data) => {
       .attr('class', 'summary-table_cell');
     body
       .append('td')
-      .text(summary[key].value)
+      .text(abbreviateNumber(summary[key].value))
+      .attr('data-title', formatNumberWithCommas(summary[key].value))
       .attr('width', 150)
       .attr('class', 'summary-table_cell');
   }
 };
+

--- a/style.css
+++ b/style.css
@@ -56,6 +56,26 @@ text {
   text-transform: capitalize;
 }
 
+[data-title]:hover:after {
+  opacity: 1;
+  transition: all 0.1s ease 0.5s;
+  visibility: visible;
+}
+[data-title]:after {
+  content: attr(data-title);
+  margin-left: 10px;
+  margin-top: 10px;
+  padding: 2px 4px;
+  color: black;
+  border-radius: 5px;
+  background-color: lightgray;
+  visibility: hidden;
+  font-size: 12px;
+}
+[data-title] {
+  position: relative;
+}
+
 .spinner {
   width: 80px;
   height: 80px;


### PR DESCRIPTION
This PR shows abbreviated values in summary table (Ex: 8500000 -> 8.5M) and on hovering over the abbreviated value, the actual value will be shown in a custom designed tooltip.

[Fix for #62] 