### PR TITLE
Change promise management

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,13 +5,12 @@ import LineChart from "./LineChart";
 
 const main = async () => {
   const overlay = document.getElementById("overlay");
-
-  await init().then((data) => {
-    LineChart(data);
-    console.log("Initialized data sets", Object.keys(data));
-    setTimeout(() => {
-      overlay.style.display = "none";
-    }, 500);
-  });
+  let data = await init();
+  LineChart(data);
+  console.log("Initialized data sets", Object.keys(data));
+  setTimeout(() => {
+    overlay.style.display = "none";
+  }, 500);
 };
+
 main();


### PR DESCRIPTION
You cannot use `.then()` after a `Function`, but you can after a `Promise<Function>`. `await` is basically an internal version of `.then()`, you can't use it with `.then()`. I deleted` .then()` and kept `await` for the coding convenience.