### PR TITLE
Restricted the chart size to fit within the screen

### DIFF
--- a/src/LineChart/line_chart.js
+++ b/src/LineChart/line_chart.js
@@ -16,7 +16,7 @@ let _initialXDomain;
 
 const calculateDimensions = () => {
   screenWidth = document.querySelector(`#${_containerId}`).clientWidth;
-  chartHeight = (screenWidth * 2) / 3;
+  chartHeight = window.innerHeight - 110;
 
   width = screenWidth - margin.left - margin.right;
   height = chartHeight - margin.top - margin.bottom;


### PR DESCRIPTION
This fixes issue #29 to make the chart height adapt to the height of the screen.