### PR TITLE
Restricted the size of the chart to the size of the screen. Fix for #29

### DIFF
--- a/src/LineChart/line_chart.js
+++ b/src/LineChart/line_chart.js
@@ -15,12 +15,18 @@ let _xAxis;
 let _initialXDomain;
 
 const calculateDimensions = () => {
-  screenWidth = document.querySelector(`#${_containerId}`).clientWidth;
-  chartHeight = (screenWidth * 2) / 3;
+  screenWidth = window.innerWidth;
+  chartHeight = window.innerHeight- getHeaderHeight() - 90;
 
   width = screenWidth - margin.left - margin.right;
   height = chartHeight - margin.top - margin.bottom;
 };
+
+const getHeaderHeight = () => {
+  const filterHeight = document.getElementById('state_select').offsetHeight;
+  const summaryTableHeight = document.getElementById('summary-table').offsetHeight;
+  return filterHeight + summaryTableHeight;
+}
 
 const redrawing = () => {
   initLineChart(_containerId, _options);

--- a/src/summaryTable.js
+++ b/src/summaryTable.js
@@ -19,7 +19,7 @@ function getTotals(data) {
  */
 export const initSummaryTable = (containerId) => {
   const id = `#${containerId}`;
-  const table = d3.select(id).append('table').attr('class', 'summary-table');
+  const table = d3.select(id).append('table').attr('id', 'summary-table');
 };
 
 function abbreviateNumber(value) {
@@ -38,7 +38,7 @@ function formatNumberWithCommas(value) {
 export const createSummaryTable = (containerId, data) => {
   const id = `#${containerId}`;
 
-  d3.select(`${id} .summary-table`).html('');
+  d3.select(`${id} #summary-table`).html('');
 
   const numPoints = data.length;
   const lastDay = data[numPoints - 1].date.getDay();
@@ -68,7 +68,7 @@ export const createSummaryTable = (containerId, data) => {
     },
   };
 
-  const table = d3.select('.summary-table');
+  const table = d3.select('#summary-table');
   const head = table.append('thead').append('tr');
   const body = table.append('tbody').append('tr');
 

--- a/style.css
+++ b/style.css
@@ -45,7 +45,7 @@ text {
   font-family: Lato, Roboto, "Open Sans", Arial, sans-serif;
 }
 
-.summary-table {
+#summary-table {
   margin-left: 50px;
   margin-top: 25px;
   border-spacing: 0;


### PR DESCRIPTION
This PR restricts the size of the chart to the size of the browser viewport. The whole chart will be visible in all devices/screen sizes.

Fix for #29 